### PR TITLE
Node 4.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:12.19.0
+FROM mhart/alpine-node:14.17.3
 
 LABEL maintainer "mersocarlin@mersocarlin.com"
 


### PR DESCRIPTION
Bump NodeJS to `mhart/alpine-node:14.17.3`